### PR TITLE
Fix required arguments issue

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -23,17 +23,14 @@ function testArgs (yargs) {
     .option('dir', {
       type: 'string',
       description: 'Directory where screenshots are stored',
-      requiresArg: true
     })
     .option('filter', {
       type: 'array',
       description: 'Only collect screenshots for these components',
-      requiresArg: true
     })
     .option('threshold', {
       type: 'number',
       description: 'Threshold for visual diffing',
-      requiresArg: true
     })
     .demandOption(['url'])
     .config('config', configParser)


### PR DESCRIPTION
This pull request fix an issue that if the user followed the instructions in the README section, it would fail due to missing arguments.

The changes were simply to remove the required arguments to let the code use the default options.

Fix #6 