### PR TITLE
Add support for using already running chromium

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -41,6 +41,7 @@ const testSchema = joi
       })
     ),
     launchOptions: joi.object(),
+    connectOptions: joi.object(),
     navigationOptions: joi.object()
   })
 
@@ -58,19 +59,21 @@ const testDefaults = {
     }
   },
   launchOptions: {},
+  connectOptions: undefined,
   navigationOptions: {}
 }
 
 async function test (partialOptions) {
   let browser
+  const useConnect = partialOptions.connectOptions !== undefined
 
   try {
     const options = await getOptions(partialOptions, testDefaults, testSchema)
-    const { url, dir, filter, threshold, viewports, launchOptions, navigationOptions } = options
+    const { url, dir, filter, threshold, viewports, launchOptions, connectOptions, navigationOptions } = options
 
     await removeNonRefScreenshots({ dir, filter })
 
-    browser = await puppeteer.launch(launchOptions)
+    browser = useConnect ? await puppeteer.connect(connectOptions) : await puppeteer.launch(launchOptions)
     const page = await browser.newPage()
 
     for (const viewport of Object.keys(viewports)) {
@@ -92,7 +95,7 @@ async function test (partialOptions) {
     debug(err)
     throw err
   } finally {
-    if (browser != null) {
+    if (useConnect === false && browser != null) {
       await browser.close()
     }
   }


### PR DESCRIPTION
In detail this means adding support for using `puppeteer.connect`. The main reason for adding this is that this allows you to run the test against an already running version of chromium (for instance one running inside a docker container).

The reason for running chrome in a container could be that developers on different operating system can generate the exact same images even if they're not running the same operating system.

### How to use
To run this you need a docker container with chromium installed (ideally one matching the version specified in the package.json of puppeteer: https://github.com/GoogleChrome/puppeteer/blob/23706188192ce1f616ae29b50010eb560ca29da9/package.json#L39)

So you can then run that container and expose the debugging port: 9222 
```bash
# Start a example container running debian + chromium
$docker run -it -p 127.0.0.1:9222:9222 drgone/chromium:chromium-67 /bin/bash -c "/usr/bin/chromium --headless --disable-gpu --remote-debugging-port=9222 --hide-scrollbars --no-sandbox --remote-debugging-address=0.0.0.0 --net=port"
```

I then have a custom test that calls the `react-styleguidist-visual` script:
``` js
const http = require('http');
const { test: visualTest } = require('react-styleguidist-visual');

// Get a websocket endpoint 
const getWSEndpoint = () => {
  return new Promise((res, reject) => {
    http.get('http://localhost:9222/json/new', resp => {
      let data = ''
      resp.on('data', chunk => {
        data += chunk;
      });
      resp.on('end', () => {
        res(JSON.parse(data).webSocketDebuggerUrl);
      })
      resp.on('error', reject);
    });
  })
};

const test = async () => {
  const browserWSEndpoint = await getWSEndpoint();

  return visualTest({
    // The site running on your machine's ip
    // localhost would not work without me exposing the 6060 port of 
    url: 'http://192.168.1.105:6060/',
    connectOptions: {
      browserWSEndpoint,
    }
  }).then(() => {
    process.exit(0);
  });
}

test().catch(err => {
  console.error('Test failed', err);
  process.exit(1);
});
```

The test script is just a quick example of how you could use this connect