### PR TITLE
Add action states

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ $ npx styleguidist-visual approve --help
 
 ### Action States
 
-You can capture screenshots after simulating an action, by providing a selector and list of actions as props to the component wrapper like this:
+You can capture screenshots after simulating an action, by providing a JSON.stringified list of actions as props to the component wrapper like this:
 
 ```
-  ```js { "props": { "data-action-selector": ".my-button", "data-action-states": "base,hover,focus,mouseDown" } }
+  ```js { "props": [{\"action\":\"none\"},{\"action\":\"hover\",\"selector\":\".y-button\"},{\"action\":\"focus\",\"selector\":\".y-button\"}] }
   <button classNames='my-button' />
 ```
 
-Available states are `base`, `hover`, `focus`, `click` and `mouseDown`.
-`base` captures the component without performing an action.
+Available actions are `none`, `hover`, `focus`, `click` and `mouseDown`.
+`none` captures the component without performing an action.
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ $ npx styleguidist-visual test --help
 $ npx styleguidist-visual approve --help
 ```
 
+### Action States
+
+You can capture screenshots after simulating an action, by providing a selector and list of actions as props to the component wrapper like this:
+
+```
+  ```js { "props": { "data-action-selector": ".my-button", "data-action-states": "base,hover,focus,mouseDown" } }
+  <button classNames='my-button' />
+```
+
+Available states are `base`, `hover`, `focus`, `click` and `mouseDown`.
+`base` captures the component with without performing an action.
+
 ### Debugging
 
 Use the `DEBUG` environment variable to see debugging statements:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can capture screenshots after simulating an action, by providing a selector 
 ```
 
 Available states are `base`, `hover`, `focus`, `click` and `mouseDown`.
-`base` captures the component with without performing an action.
+`base` captures the component without performing an action.
 
 ### Debugging
 

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -79,7 +79,7 @@ async function test (partialOptions) {
     for (const viewport of Object.keys(viewports)) {
       const progress = spinner({
         start: `Taking screenshots for viewport ${viewport}`,
-        update: `Taking screenshot %s of %s for viewport ${viewport}`,
+        update: `Taking screenshot of component %s of %s for viewport ${viewport}`,
         stop: `Finished taking screenshots for viewport ${viewport}`
       })
       progress.start()

--- a/src/utils/page.js
+++ b/src/utils/page.js
@@ -97,7 +97,7 @@ async function takeNewScreenshotOfPreview (page, preview, index, actionState, { 
 }
 
 async function triggerAction(page, el, action, actionSelector) {
-  const actionEl = await el.$(actionSelector)
+  const actionEl = await (actionSelector ? el.$(actionSelector) : el)
   switch(action) {
     case 'hover':
       await actionEl.hover()

--- a/src/utils/page.js
+++ b/src/utils/page.js
@@ -28,6 +28,8 @@ function getPreviewsInPage ({ filter, viewport }) {
     const url = el.nextSibling.querySelector('a[href][title]').href
     const name = el.dataset.preview
     const description = el.dataset.description
+    const actionStates = el.dataset.actionStates
+    const actionSelector = el.dataset.actionSelector
 
     if (!shouldIncludePreview(name)) {
       return memo
@@ -37,8 +39,11 @@ function getPreviewsInPage ({ filter, viewport }) {
       url,
       name,
       description,
+      actionStates,
+      actionSelector,
       viewport
     })
+
     return memo
   }
 
@@ -58,31 +63,63 @@ async function takeNewScreenshotsOfPreviews (page, previewMap, { dir, progress, 
     let previewIndex = 1
 
     for (const preview of previewList) {
+      const actionStateList = preview.actionStates ? preview.actionStates.split(',') : ['base']
+
       progress.update(progressIndex, progressTotal)
 
       const { url } = preview
       await goToHashUrl(page, url)
-      await takeNewScreenshotOfPreview(page, preview, previewIndex, { dir })
 
-      previewIndex += 1
+      for(const actionState of actionStateList) {
+        await takeNewScreenshotOfPreview(page, preview, previewIndex, actionState, { dir })
+        previewIndex += 1
+      }
+
       progressIndex += 1
     }
   }
 }
 
-async function takeNewScreenshotOfPreview (page, preview, index, { dir }) {
-  const { name, description = `${index}`, viewport } = preview
-  const basename = `${name} ${description.toLowerCase()} ${viewport.toLowerCase()}`.replace(/[^0-9A-Z]+/gi, '_')
+async function takeNewScreenshotOfPreview (page, preview, index, actionState, { dir }) {
+  const { name, description = `${index}`, actionSelector, viewport } = preview
+  const actionStateForFilename = actionState === 'base' ? ' ' : ` ${actionState} `
+  const basename = `${name} ${description.toLowerCase()}${actionStateForFilename}${viewport.toLowerCase()}`.replace(/[^0-9A-Z]+/gi, '_')
   const relativePath = path.join(dir, `${basename}.new.png`)
 
-  const clip = await page.evaluate(() => {
-    const el = document.querySelector('[data-preview]')
-    const { x, y, width, height } = el.getBoundingClientRect()
-    return { x, y, width, height }
-  })
+  const el = await page.$('[data-preview]')
+  const boundingBox = await el.boundingBox()
+
+  await triggerAction(page, el, actionState, actionSelector)
 
   debug('Storing screenshot of %s in %s', chalk.blue(name), chalk.cyan(relativePath))
-  await page.screenshot({ clip, path: relativePath })
+  await page.screenshot({ clip: boundingBox, path: relativePath })
+  await resetMouseAndFocus(page)
+}
+
+async function triggerAction(page, el, action, actionSelector) {
+  const actionEl = await el.$(actionSelector)
+  switch(action) {
+    case 'hover':
+      await actionEl.hover()
+      break
+    case 'click':
+      await actionEl.click()
+      break
+    case 'mouseDown':
+      const box = await actionEl.boundingBox()
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+      await page.mouse.down()
+      break
+    case 'focus':
+      await actionEl.focus()
+      break
+  }
+}
+
+async function resetMouseAndFocus(page) {
+  await page.focus('body')
+  await page.mouse.up()
+  await page.mouse.move(0,0)
 }
 
 async function goToUrl (page, url, navigationOptions) {


### PR DESCRIPTION
### Action States

You can capture screenshots after simulating an action, by providing a JSON.stringified list of actions as props to the component wrapper like this:

```
  ```js { "props": [{\"action\":\"none\"},{\"action\":\"hover\",\"selector\":\".y-button\"},{\"action\":\"focus\",\"selector\":\".y-button\"}] }
  <button classNames='my-button' />
```

Available actions are `none`, `hover`, `focus`, `click` and `mouseDown`.
`none` captures the component without performing an action.