### PR TITLE
Action State Selector Fallback

### DIFF
--- a/src/utils/page.js
+++ b/src/utils/page.js
@@ -95,7 +95,7 @@ async function takeNewScreenshotOfPreview (page, preview, index, actionState, { 
 }
 
 async function triggerAction(page, el, actionState) {
-  const actionEl = await (actionState.selector ? el.$(actionState.selector) : el)
+  const actionEl = actionState.selector ? await el.$(actionState.selector) || await page.$(actionState.selector) : el
   switch(actionState.action) {
     case 'hover':
       await actionEl.hover()


### PR DESCRIPTION
Fallback to looking on the page if the selector cannot be found within the component.

This is useful for components like dropdown where a callout can be rendered outside of the component.  