### PR TITLE
Action State Chaining

### DIFF
--- a/src/utils/page.js
+++ b/src/utils/page.js
@@ -72,7 +72,7 @@ async function takeNewScreenshotsOfPreviews (page, previewMap, { dir, progress, 
         await takeNewScreenshotOfPreview(page, preview, previewIndex, actionState, { dir })
         previewIndex += 1
       }
-
+      await resetMouseAndFocus(page)
       progressIndex += 1
     }
   }
@@ -91,7 +91,6 @@ async function takeNewScreenshotOfPreview (page, preview, index, actionState, { 
 
   debug('Storing screenshot of %s in %s', chalk.blue(name), chalk.cyan(relativePath))
   await page.screenshot({ clip: boundingBox, path: relativePath })
-  await resetMouseAndFocus(page)
 }
 
 async function triggerAction(page, el, actionState) {


### PR DESCRIPTION
Only reset mouse and keyboard after whole component is done.

This will allow us to more easily chain actions together.  

For example, 
1. click on a dropdown
2. press the down key

If focus is reset between this will not work. 