### PR TITLE
Add Key to Filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ npx styleguidist-visual approve --help
 You can capture screenshots after simulating an action, by providing a JSON.stringified list of actions as props to the component wrapper like this:
 
 ```
-  ```js { "props": { "data-action-states": "[{\"action\":\"none\"},{\"action\":\"hover\",\"selector\":\".my-button\",\"wait\":\"1000\"},{\"action\":\"focus\",\"selector\":\".my-button\"}]" } }
+  ```js { "props": { "data-action-states": "[{\"action\":\"none\"},{\"action\":\"hover\",\"selector\":\".my-button\",\"wait\":\"1000\"},{\"action\":\"focus\",\"selector\":\".my-button\"},{\"action\":\"keyPress\",\"key\":\"Tab\"}]" } }
   <button classNames='my-button' />
 ```
 
@@ -51,7 +51,7 @@ Available actions are `none`, `hover`, `focus`, `click`, `mouseDown` and `keyPre
 
 `none` - captures the component without performing an action.
 
-`keyPress` - use `selector` to specify the [key](https://github.com/GoogleChrome/puppeteer/blob/v1.4.0/lib/USKeyboardLayout.js).
+`keyPress` - use `key` to specify the [key](https://github.com/GoogleChrome/puppeteer/blob/v1.4.0/lib/USKeyboardLayout.js).
 
 `wait` - an optional time in ms to wait between performing the action and snapping the screenshot.
 


### PR DESCRIPTION
To help differentiate different keyPress action states.

- extracted a new `getRelativeFilepath` function
- switched from using `selector` to `key` to specify key