### PR TITLE
Add --wait cli option for the test command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -32,6 +32,10 @@ function testArgs (yargs) {
       type: 'number',
       description: 'Threshold for visual diffing'
     })
+    .option('wait', {
+      type: 'number',
+      description: 'Delay before taking screenshot (in milliseconds)'
+    })
     .demandOption(['url'])
     .config('config', configParser)
     .example(

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -20,6 +20,7 @@ const testSchema = joi
       .number()
       .min(0)
       .max(1),
+    wait: joi.number(),
     viewports: joi.object().pattern(
       /^.+$/,
       joi.object().keys({
@@ -51,6 +52,7 @@ const testDefaults = {
   dir: 'styleguide-visual',
   filter: undefined,
   threshold: 0.001,
+  wait: 0,
   viewports: {
     desktop: {
       width: 800,
@@ -69,7 +71,7 @@ async function test (partialOptions) {
 
   try {
     const options = await getOptions(partialOptions, testDefaults, testSchema)
-    const { url, dir, filter, threshold, viewports, launchOptions, connectOptions, navigationOptions } = options
+    const { url, dir, filter, threshold, wait, viewports, launchOptions, connectOptions, navigationOptions } = options
 
     await removeNonRefScreenshots({ dir, filter })
 
@@ -85,7 +87,7 @@ async function test (partialOptions) {
       progress.start()
       await page.setViewport(viewports[viewport])
       const previews = await getPreviews(page, { url, filter, viewport, navigationOptions })
-      await takeNewScreenshotsOfPreviews(page, previews, { dir, progress, navigationOptions })
+      await takeNewScreenshotsOfPreviews(page, previews, { dir, progress, navigationOptions, wait })
       progress.stop()
     }
 

--- a/src/utils/page.js
+++ b/src/utils/page.js
@@ -49,7 +49,7 @@ function getPreviewsInPage ({ filter, viewport }) {
   return Array.prototype.reduce.call(result, extractPreviewInfo, {})
 }
 
-async function takeNewScreenshotsOfPreviews (page, previewMap, { dir, progress, navigationOptions }) {
+async function takeNewScreenshotsOfPreviews (page, previewMap, { dir, progress, navigationOptions, wait }) {
   await ensureDir(dir)
 
   let progressIndex = 1
@@ -69,7 +69,7 @@ async function takeNewScreenshotsOfPreviews (page, previewMap, { dir, progress, 
       await goToHashUrl(page, url)
 
       for(const actionState of actionStateList) {
-        await takeNewScreenshotOfPreview(page, preview, previewIndex, actionState, { dir })
+        await takeNewScreenshotOfPreview(page, preview, previewIndex, actionState, { dir, wait })
         previewIndex += 1
       }
       await resetMouseAndFocus(page)
@@ -78,8 +78,13 @@ async function takeNewScreenshotsOfPreviews (page, previewMap, { dir, progress, 
   }
 }
 
-async function takeNewScreenshotOfPreview (page, preview, index, actionState, { dir }) {
+async function takeNewScreenshotOfPreview (page, preview, index, actionState, { dir, delay: wait }) {
   const el = await page.$('[data-preview]')
+
+  if (wait) {
+    await sleep(wait)
+  }
+
   const boundingBox = await el.boundingBox()
 
   await triggerAction(page, el, actionState)

--- a/src/utils/page.js
+++ b/src/utils/page.js
@@ -78,7 +78,7 @@ async function takeNewScreenshotsOfPreviews (page, previewMap, { dir, progress, 
   }
 }
 
-async function takeNewScreenshotOfPreview (page, preview, index, actionState, { dir, delay: wait }) {
+async function takeNewScreenshotOfPreview (page, preview, index, actionState, { dir, wait }) {
   const el = await page.$('[data-preview]')
 
   if (wait) {


### PR DESCRIPTION
Hello there, 

In my tests I quite often run into an issue when screenshot is being taken before example is fully rendered. So I've added wait option to the styleguidist-visual test command which could help to solve such issues.

Here is an example of incorrect screenshots
Button_1_desktop.new.png
![button_1_desktop new](https://user-images.githubusercontent.com/8017482/41201220-61c37a5c-6cbc-11e8-9629-a8eb81007d74.png)
Button_1_desktop.png
![button_1_desktop](https://user-images.githubusercontent.com/8017482/41201221-627c97c6-6cbc-11e8-9ceb-b81cf4226c0b.png)
