### PR TITLE
Making use of elementHandle.screenshot

### DIFF
--- a/src/utils/page.js
+++ b/src/utils/page.js
@@ -90,11 +90,21 @@ async function takeNewScreenshotOfPreview (page, preview, index, actionState, { 
   await triggerAction(page, el, actionState)
 
   const boundingBoxEl = preview.previewSelector ? await page.$(preview.previewSelector) : el
-  const boundingBox = await boundingBoxEl.boundingBox()
+
+  const isVisible = await page.evaluate((element) => {
+    if (!element) {
+      return false
+    }
+    const style = window.getComputedStyle(element)
+    return style && style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0'
+  }, boundingBoxEl)
 
   const path = await getRelativeFilepath(preview, index, actionState, dir)
   debug('Storing screenshot of %s in %s', chalk.blue(preview.name), chalk.cyan(path))
-  await page.screenshot({ clip: boundingBox, path })
+
+  if (isVisible) {
+    await boundingBoxEl.screenshot({ path })
+  }
 }
 
 async function getRelativeFilepath (preview, index, actionState, dir) {


### PR DESCRIPTION
Hi,

I just wanted to ask if the use of `page.screenshot` was intentional or if you would like to use the `elementHandle.screenshot` method instead. ([See puppeteer docs](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#elementhandlescreenshotoptions))

I had to change it in my styleguidist project since puppeteer would always take a screenshot of the "props & methods" table after it triggered a click action on a button which toggled the components content.

Before changing the code to use `elementHandle.screenshot` I tried to set the `--wait` option globally and also for the single click action but none helped. But after I changed the code to use `elementHandle.screenshot` it worked really well.

Best regards

Eric