### PR TITLE
Add new option deleteScreenshotsWhenAccepted

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -52,6 +52,7 @@ const testDefaults = {
   dir: 'styleguide-visual',
   filter: undefined,
   threshold: 0.001,
+  deleteScreenshotsWhenAccepted: false,
   wait: 0,
   viewports: {
     desktop: {
@@ -71,7 +72,7 @@ async function test (partialOptions) {
 
   try {
     const options = await getOptions(partialOptions, testDefaults, testSchema)
-    const { url, dir, filter, threshold, wait, viewports, launchOptions, connectOptions, navigationOptions } = options
+    const { url, dir, filter, threshold, wait, viewports, launchOptions, connectOptions, navigationOptions, deleteScreenshotsWhenAccepted } = options
 
     await removeNonRefScreenshots({ dir, filter })
 
@@ -92,7 +93,7 @@ async function test (partialOptions) {
     }
 
     await checkForStaleRefScreenshots({ dir, filter })
-    await compareNewScreenshotsToRefScreenshots({ dir, filter, threshold })
+    await compareNewScreenshotsToRefScreenshots({ dir, filter, threshold, deleteScreenshotsWhenAccepted })
   } catch (err) {
     debug(err)
     throw err

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -35,7 +35,7 @@ async function checkForStaleRefScreenshots ({ dir, filter }) {
   }
 }
 
-async function compareNewScreenshotsToRefScreenshots ({ dir, filter, threshold }) {
+async function compareNewScreenshotsToRefScreenshots ({ dir, filter, threshold, deleteScreenshotsWhenAccepted }) {
   const newImgs = await glob(path.join(dir, `${filter || ''}*.new.png`))
 
   let diffCount = 0
@@ -51,6 +51,10 @@ async function compareNewScreenshotsToRefScreenshots ({ dir, filter, threshold }
       const pixels = await diffScreenshots(newImg, refImg, diffImg, threshold)
       if (pixels === 0) {
         success('Screenshots %s and %s match', chalk.cyan(newImg), chalk.cyan(refImg))
+        if (deleteScreenshotsWhenAccepted) {
+          await remove(newImg)
+          await remove(diffImg)
+        }
       } else {
         failure('Screenshots %s and %s differ in %s pixels', chalk.cyan(newImg), chalk.cyan(refImg), chalk.red(pixels))
         termImg(diffImg, {


### PR DESCRIPTION
This introduces a new option that can be used to make sure when your threshold is high and one pixel for example changes that it won't replace the screenshot when you approve it.

This removes a lot of noise/manual work, since we never want to see the screenshots that got accepted. Right now we are manually removing those screenshots. Nothing *really* changed, so they should not be replaced when they got approved. We use docker but even with the same docker image they might be 1-pixel-off aliasing issues.

Let me know what you think about, I would be happy if this could be merged and released, hopefully other people find it useful, too.